### PR TITLE
Fix: Allow custom client to be passed to ChatDatabricks

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -252,7 +252,10 @@ class ChatDatabricks(BaseChatModel):
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
-        self.client = get_deployment_client(self.target_uri)
+        if "client" in kwargs:
+            self.client = kwargs["client"]
+        else:
+            self.client = get_deployment_client(self.target_uri)
         self.extra_params = self.extra_params or {}
 
     @property


### PR DESCRIPTION
This commit addresses issue #128 by modifying the `__init__` method of the `ChatDatabricks` class to allow a custom client to be passed in via the constructor.

Previously, any client passed in the constructor would be overwritten by the default client. With this change:
- If a `client` is provided in `kwargs`, that client instance is used.
- Otherwise, the client is initialized using `get_deployment_client(self.target_uri)`.

A new unit test, `test_chat_model_with_custom_client`, has been added to `integrations/langchain/tests/unit_tests/test_chat_models.py` to verify this functionality. The test ensures that the provided custom client is correctly assigned and its methods are called when the `ChatDatabricks` instance makes predictions.